### PR TITLE
Add cmake install rules for proxyd, libproxy and libzlog

### DIFF
--- a/bld/src/libproxy/CMakeLists.txt
+++ b/bld/src/libproxy/CMakeLists.txt
@@ -285,6 +285,8 @@ if(${use_openssl})
     target_link_libraries(libproxy-static PUBLIC ${OPENSSL_LIBRARIES})
 endif()
 
-if(LINUX)
+if(WIN32)
+  # Place here the install rule for win32
+elseif(LINUX)
 	install (TARGETS libproxy LIBRARY DESTINATION lib )
 endif()

--- a/bld/src/libproxy/CMakeLists.txt
+++ b/bld/src/libproxy/CMakeLists.txt
@@ -285,4 +285,6 @@ if(${use_openssl})
     target_link_libraries(libproxy-static PUBLIC ${OPENSSL_LIBRARIES})
 endif()
 
-install (TARGETS libproxy LIBRARY DESTINATION lib )
+if(LINUX)
+	install (TARGETS libproxy LIBRARY DESTINATION lib )
+endif()

--- a/bld/src/libproxy/CMakeLists.txt
+++ b/bld/src/libproxy/CMakeLists.txt
@@ -284,3 +284,5 @@ if(${use_openssl})
 	target_compile_definitions(libproxy PRIVATE USE_OPENSSL=1)
     target_link_libraries(libproxy-static PUBLIC ${OPENSSL_LIBRARIES})
 endif()
+
+install (TARGETS libproxy LIBRARY DESTINATION lib )

--- a/bld/src/libzlog/CMakeLists.txt
+++ b/bld/src/libzlog/CMakeLists.txt
@@ -59,3 +59,6 @@ else()
         target_compile_definitions(libzlog PRIVATE _HAVE_PTHREAD_H=1)
     endif()
 endif()
+
+
+install (TARGETS libzlog LIBRARY DESTINATION lib )

--- a/bld/src/libzlog/CMakeLists.txt
+++ b/bld/src/libzlog/CMakeLists.txt
@@ -60,5 +60,6 @@ else()
     endif()
 endif()
 
-
-install (TARGETS libzlog LIBRARY DESTINATION lib )
+if(LINUX)
+	install (TARGETS libzlog LIBRARY DESTINATION lib )
+endif()

--- a/bld/src/libzlog/CMakeLists.txt
+++ b/bld/src/libzlog/CMakeLists.txt
@@ -60,6 +60,8 @@ else()
     endif()
 endif()
 
-if(LINUX)
+if(WIN32)
+  # Place here the install rule for win32
+elseif(LINUX)
 	install (TARGETS libzlog LIBRARY DESTINATION lib )
 endif()

--- a/bld/src/proxyd/CMakeLists.txt
+++ b/bld/src/proxyd/CMakeLists.txt
@@ -50,3 +50,5 @@ if(CMAKE_CROSSCOMPILING)
     target_link_libraries(proxyd ${FFI_LIBRARY})
   endif()
 endif()
+
+install (TARGETS proxyd RUNTIME DESTINATION bin )

--- a/bld/src/proxyd/CMakeLists.txt
+++ b/bld/src/proxyd/CMakeLists.txt
@@ -51,6 +51,8 @@ if(CMAKE_CROSSCOMPILING)
   endif()
 endif()
 
-if(LINUX)
+if(WIN32)
+  # Place here the install rule for win32
+elseif(LINUX)
     install (TARGETS proxyd RUNTIME DESTINATION bin )
 endif()

--- a/bld/src/proxyd/CMakeLists.txt
+++ b/bld/src/proxyd/CMakeLists.txt
@@ -51,4 +51,6 @@ if(CMAKE_CROSSCOMPILING)
   endif()
 endif()
 
-install (TARGETS proxyd RUNTIME DESTINATION bin )
+if(LINUX)
+    install (TARGETS proxyd RUNTIME DESTINATION bin )
+endif()

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ install the required build dependencies: ```sudo apt-get install bash git cmake 
 - (Optional) To build the dotnet samples and API, follow the instructions [here](https://www.microsoft.com/net/core#linuxubuntu) to
 install .net Core.
 - Run ```bash <repo-root>/bld/build.sh```.  After a successful build, all proxy binaries can be found under the /build/cmake/bin folder.
-- (Optional) To install run the usual ```make install``` in directory <repo-root>/build/cmake/Release or <repo-root>/build/cmake/Debug.
+- (Optional) To install run the usual ```make install``` in directory build/cmake/Release or build/cmake/Debug.
              For a test install to /tmp/azure you could use for example the following: ```make -C <repo-root>/build/cmake/Debug  DESTDIR=/tmp/azure install```. Then run the proxy: ```LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tmp/azure/usr/local/lib /tmp/azure/usr/local/bin/proxyd --help```
 
 Run the build script with the ```--help``` option to see all configuration options available.

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ install the required build dependencies: ```sudo apt-get install bash git cmake 
 - (Optional) To build the dotnet samples and API, follow the instructions [here](https://www.microsoft.com/net/core#linuxubuntu) to
 install .net Core.
 - Run ```bash <repo-root>/bld/build.sh```.  After a successful build, all proxy binaries can be found under the /build/cmake/bin folder.
+- (Optional) To install run the usual ```make install``` in directory <repo-root>/build/cmake/Release or <repo-root>/build/cmake/Debug.
+             For a test install to /tmp/azure you could use for example the following: ```make -C <repo-root>/build/cmake/Debug  DESTDIR=/tmp/azure install```. Then run the proxy: ```LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tmp/azure/usr/local/lib /tmp/azure/usr/local/bin/proxyd --help```
 
 Run the build script with the ```--help``` option to see all configuration options available.
 


### PR DESCRIPTION
Hello,

This pull request adds cmake install rules for the in Linux usual call of make install.
